### PR TITLE
feat: add OIDC login

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,18 @@ Or with pipx:
 |---|---|---|
 | `ODSBOX_STATS_ENABLED` | not set (disabled) | Set to `1`, `true`, or `yes` to enable tool and resource call monitoring. Statistics are persisted to a SQLite database (`odsbox-jaquel-mcp-stats.db`) for cross-session tracking. |
 | `FASTMCP_LOG_LEVEL` | `INFO` | Controls the server-side log level (`DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`). With stdio transport all logs go to stderr, which MCP clients may display as warnings. Set to `WARNING` to reduce noise. |
+| `ODSBOX_MCP_MODE` | `basic` | Authentication mode for `ods_connect_using_env`: `basic`, `m2m`, or `oidc` |
 | `ODSBOX_MCP_URL` | not set | ODS server URL for `ods_connect_using_env` |
-| `ODSBOX_MCP_USER` | not set | ODS username for `ods_connect_using_env` |
-| `ODSBOX_MCP_PASSWORD` | not set | ODS password for `ods_connect_using_env` |
+| `ODSBOX_MCP_USER` | not set | ODS username (basic mode) |
+| `ODSBOX_MCP_PASSWORD` | not set | ODS password (basic mode; falls back to keyring) |
+| `ODSBOX_MCP_M2M_TOKEN_ENDPOINT` | not set | OAuth2 token endpoint (m2m mode) |
+| `ODSBOX_MCP_M2M_CLIENT_ID` | not set | Client ID (m2m mode) |
+| `ODSBOX_MCP_M2M_CLIENT_SECRET` | not set | Client secret (m2m mode; falls back to keyring) |
+| `ODSBOX_MCP_OIDC_CLIENT_ID` | not set | Client ID (oidc mode) |
+| `ODSBOX_MCP_OIDC_REDIRECT_URI` | not set | Redirect URI (oidc mode, e.g. `http://127.0.0.1:1234`) |
+| `ODSBOX_MCP_VERIFY` | `true` | TLS certificate verification (`true`/`false`) |
+
+See [TOOLS_GUIDE.md](TOOLS_GUIDE.md#ods_connect_using_env) for the full list of authentication variables and keyring fallback details.
 
 ### Usage Monitoring
 
@@ -334,7 +343,7 @@ Solution: Check URL, server availability, firewall
 
 ![install in VSCode](https://github.com/totonga/odsbox-jaquel-mcp/blob/main/docs/install_in_vscode.gif){width=300px}
 
-Try with example server configuration:
+Try with example server configuration using all three authentication modes via different env prefixes:
 
 ```json
 {
@@ -348,7 +357,15 @@ Try with example server configuration:
 			"env": {
 				"ODSBOX_MCP_URL": "https://docker.peak-solution.de:10032/api",
 				"ODSBOX_MCP_USER": "Demo",
-				"ODSBOX_MCP_PASSWORD": "mdm"
+				"ODSBOX_MCP_PASSWORD": "mdm",
+				"ODSBOX_MCP2_MODE": "m2m",
+				"ODSBOX_MCP2_URL": "https://ods.example.com/api",
+				"ODSBOX_MCP2_M2M_TOKEN_ENDPOINT": "https://auth.example.com/realms/myrealm/protocol/openid-connect/token",
+				"ODSBOX_MCP2_M2M_CLIENT_ID": "my-service-client",
+				"ODSBOX_MCP3_MODE": "oidc",
+				"ODSBOX_MCP3_URL": "https://ods.example.com/api",
+				"ODSBOX_MCP3_OIDC_CLIENT_ID": "my-oidc-client",
+				"ODSBOX_MCP3_OIDC_REDIRECT_URI": "http://127.0.0.1:1234"
 			}
 		}
 	},

--- a/TOOLS_GUIDE.md
+++ b/TOOLS_GUIDE.md
@@ -423,15 +423,57 @@ else:
 
 **Purpose**: Establish connection to ASAM ODS server using environment variables.
 
-**Supported environment variables (default prefix `ODSBOX_MCP`)**:
-- `ODSBOX_MCP_URL` / `ODSBOX_MCP_API_URL`
-- `ODSBOX_MCP_USERNAME` / `ODSBOX_MCP_USER`
-- `ODSBOX_MCP_PASSWORD` / `ODSBOX_MCP_PWD`
-- `ODSBOX_MCP_VERIFY` (true/false)
+Supports three authentication modes controlled by `{PREFIX}_MODE` (default: `basic`). The default prefix is `ODSBOX_MCP`; all variables also fall back to the `ODS_` legacy prefix.
 
 You can override the prefix using either:
 - tool argument: `env_prefix`
 - environment variable: `ODSBOX_MCP_ENV_PREFIX`
+
+#### Mode: basic (default)
+
+| Variable | Required | Description |
+|---|---|---|
+| `{PREFIX}_URL` / `{PREFIX}_API_URL` | Yes | ODS server API URL |
+| `{PREFIX}_USERNAME` / `{PREFIX}_USER` | Yes | Username |
+| `{PREFIX}_PASSWORD` / `{PREFIX}_PWD` | Yes* | Password |
+| `{PREFIX}_VERIFY` | No | TLS verification (`true`/`false`, default `true`) |
+
+#### Mode: m2m (machine-to-machine)
+
+Set `{PREFIX}_MODE=m2m`.
+
+| Variable | Required | Description |
+|---|---|---|
+| `{PREFIX}_URL` | Yes | ODS server API URL |
+| `{PREFIX}_M2M_TOKEN_ENDPOINT` | Yes | OAuth2 token endpoint URL |
+| `{PREFIX}_M2M_CLIENT_ID` | Yes | Client ID |
+| `{PREFIX}_M2M_CLIENT_SECRET` | Yes* | Client secret |
+| `{PREFIX}_M2M_SCOPE` | No | Comma-separated scopes |
+| `{PREFIX}_VERIFY` | No | TLS verification |
+
+#### Mode: oidc (interactive browser login)
+
+Set `{PREFIX}_MODE=oidc`.
+
+| Variable | Required | Description |
+|---|---|---|
+| `{PREFIX}_URL` | Yes | ODS server API URL |
+| `{PREFIX}_OIDC_CLIENT_ID` | Yes | Client ID |
+| `{PREFIX}_OIDC_REDIRECT_URI` | Yes | Redirect URI (e.g., `http://127.0.0.1:1234`) |
+| `{PREFIX}_OIDC_CLIENT_SECRET` | No | Client secret (not needed for public clients) |
+| `{PREFIX}_OIDC_AUTHORIZATION_ENDPOINT` | No | Explicit authorization URL (skips WebFinger) |
+| `{PREFIX}_OIDC_TOKEN_ENDPOINT` | No | Explicit token URL (skips WebFinger) |
+| `{PREFIX}_OIDC_WEBFINGER_PATH_PREFIX` | No | WebFinger path prefix |
+| `{PREFIX}_OIDC_REDIRECT_INSECURE` | No | Allow HTTP redirect (`true`/`false`) |
+| `{PREFIX}_OIDC_LOGIN_TIMEOUT` | No | Browser login timeout in seconds (default `60`) |
+| `{PREFIX}_OIDC_SCOPE` | No | Comma-separated scopes |
+| `{PREFIX}_VERIFY` | No | TLS verification |
+
+> **Keyring fallback**: Secrets marked with \* fall back to the system keyring when the env var is absent.
+> Store secrets with `keyring set '<service>' '<username>'`:
+> - Basic: `keyring set '<URL>' '<username>'`
+> - M2M: `keyring set '<token_endpoint>' '<client_id>'`
+> - OIDC: `keyring set '<URL>' '<client_id>'` (optional for public clients)
 
 **Input**:
 ```json

--- a/odsbox_jaquel_mcp/auth_factory.py
+++ b/odsbox_jaquel_mcp/auth_factory.py
@@ -203,7 +203,7 @@ def _resolve_oidc_auth(env: os._Environ, prefix: str) -> dict[str, Any]:  # type
             login_timeout = int(login_timeout_str.strip())
         except ValueError:
             raise ValueError(
-                f"Environment variable {prefix}_OIDC_LOGIN_TIMEOUT must be an integer, " f"got: {login_timeout_str!r}"
+                f"Environment variable {prefix}_OIDC_LOGIN_TIMEOUT must be an integer, got: {login_timeout_str!r}"
             )
 
     # Optional: scope

--- a/odsbox_jaquel_mcp/auth_factory.py
+++ b/odsbox_jaquel_mcp/auth_factory.py
@@ -1,0 +1,262 @@
+"""Authentication factory for resolving ODS connection parameters from environment variables.
+
+Supports three authentication modes via ConIFactory:
+- basic: Username/password authentication (default, backward compatible)
+- m2m: Machine-to-machine OAuth2 client credentials
+- oidc: OpenID Connect interactive browser login
+
+Secrets (passwords, client_secrets) fall back to keyring lookup when not
+found in environment variables.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, cast
+
+logger = logging.getLogger(__name__)
+
+VALID_MODES = ("basic", "m2m", "oidc")
+
+
+def _get_secret_from_keyring(service: str, username: str) -> str | None:
+    """Retrieve a secret from keyring, returning None if unavailable.
+
+    Args:
+        service: Keyring service name (typically the URL or token endpoint).
+        username: Keyring username (typically the user or client_id).
+
+    Returns:
+        The secret string, or None if keyring is not installed or the secret is not found.
+    """
+    try:
+        import keyring
+
+        return cast(str | None, keyring.get_password(service, username))
+    except Exception:
+        return None
+
+
+def _env_get(env: os._Environ, prefix: str, key: str) -> str | None:  # type: ignore[type-arg]
+    """Look up an environment variable with prefix fallback to ODS_ legacy prefix."""
+    return env.get(f"{prefix}_{key}") or env.get(f"ODS_{key}")
+
+
+def _parse_verify(env: os._Environ, prefix: str) -> bool:  # type: ignore[type-arg]
+    """Parse the VERIFY environment variable as a boolean."""
+    verify_str = _env_get(env, prefix, "VERIFY")
+    if verify_str is None or str(verify_str).strip() == "":
+        return True
+    return str(verify_str).strip().lower() in ("1", "true", "yes", "y")
+
+
+def _require_url(env: os._Environ, prefix: str) -> str:  # type: ignore[type-arg]
+    """Resolve and validate the ODS server URL from environment."""
+    url = _env_get(env, prefix, "URL") or _env_get(env, prefix, "API_URL")
+    if not url or not isinstance(url, str) or not url.strip():
+        raise ValueError(
+            f"Environment variable {prefix}_URL (or {prefix}_API_URL) " "must be set to a non-empty string"
+        )
+    return url.strip()
+
+
+def _resolve_basic_auth(env: os._Environ, prefix: str) -> dict[str, Any]:  # type: ignore[type-arg]
+    """Resolve basic authentication parameters from environment.
+
+    Falls back to keyring for password if not found in environment.
+    """
+    url = _require_url(env, prefix)
+
+    username = _env_get(env, prefix, "USERNAME") or _env_get(env, prefix, "USER")
+    if not username or not isinstance(username, str) or not username.strip():
+        raise ValueError(
+            f"Environment variable {prefix}_USERNAME (or {prefix}_USER) " "must be set to a non-empty string"
+        )
+    username = username.strip()
+
+    password = _env_get(env, prefix, "PASSWORD") or _env_get(env, prefix, "PWD")
+    if not password or not isinstance(password, str) or not password.strip():
+        # Keyring fallback
+        password = _get_secret_from_keyring(url, username)
+        if not password:
+            raise ValueError(
+                f"Password not found. Set {prefix}_PASSWORD (or {prefix}_PWD) "
+                f"or store it in keyring:\n"
+                f"  keyring set '{url}' '{username}'"
+            )
+    else:
+        password = password.strip()
+
+    return {
+        "mode": "basic",
+        "url": url,
+        "username": username,
+        "password": password,
+        "verify_certificate": _parse_verify(env, prefix),
+    }
+
+
+def _resolve_m2m_auth(env: os._Environ, prefix: str) -> dict[str, Any]:  # type: ignore[type-arg]
+    """Resolve M2M (machine-to-machine) authentication parameters from environment.
+
+    Falls back to keyring for client_secret if not found in environment.
+    """
+    url = _require_url(env, prefix)
+
+    token_endpoint = _env_get(env, prefix, "M2M_TOKEN_ENDPOINT")
+    if not token_endpoint or not isinstance(token_endpoint, str) or not token_endpoint.strip():
+        raise ValueError(
+            f"Environment variable {prefix}_M2M_TOKEN_ENDPOINT must be set for M2M mode "
+            "(e.g., https://auth.example.com/realms/myrealm/protocol/openid-connect/token)"
+        )
+    token_endpoint = token_endpoint.strip()
+
+    client_id = _env_get(env, prefix, "M2M_CLIENT_ID")
+    if not client_id or not isinstance(client_id, str) or not client_id.strip():
+        raise ValueError(f"Environment variable {prefix}_M2M_CLIENT_ID must be set for M2M mode")
+    client_id = client_id.strip()
+
+    client_secret = _env_get(env, prefix, "M2M_CLIENT_SECRET")
+    if not client_secret or not isinstance(client_secret, str) or not client_secret.strip():
+        # Keyring fallback
+        client_secret = _get_secret_from_keyring(token_endpoint, client_id)
+        if not client_secret:
+            raise ValueError(
+                f"Client secret not found. Set {prefix}_M2M_CLIENT_SECRET "
+                f"or store it in keyring:\n"
+                f"  keyring set '{token_endpoint}' '{client_id}'"
+            )
+    else:
+        client_secret = client_secret.strip()
+
+    # Scope is optional, comma-separated
+    scope_str = _env_get(env, prefix, "M2M_SCOPE")
+    scope: list[str] | None = None
+    if scope_str and scope_str.strip():
+        scope = [s.strip() for s in scope_str.split(",") if s.strip()]
+
+    return {
+        "mode": "m2m",
+        "url": url,
+        "token_endpoint": token_endpoint,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "scope": scope,
+        "verify_certificate": _parse_verify(env, prefix),
+    }
+
+
+def _resolve_oidc_auth(env: os._Environ, prefix: str) -> dict[str, Any]:  # type: ignore[type-arg]
+    """Resolve OIDC authentication parameters from environment.
+
+    client_secret is optional (public clients do not require one).
+    Falls back to keyring for client_secret if not found in environment.
+    """
+    url = _require_url(env, prefix)
+
+    client_id = _env_get(env, prefix, "OIDC_CLIENT_ID")
+    if not client_id or not isinstance(client_id, str) or not client_id.strip():
+        raise ValueError(f"Environment variable {prefix}_OIDC_CLIENT_ID must be set for OIDC mode")
+    client_id = client_id.strip()
+
+    redirect_uri = _env_get(env, prefix, "OIDC_REDIRECT_URI")
+    if not redirect_uri or not isinstance(redirect_uri, str) or not redirect_uri.strip():
+        raise ValueError(
+            f"Environment variable {prefix}_OIDC_REDIRECT_URI must be set for OIDC mode "
+            "(e.g., http://127.0.0.1:1234)"
+        )
+    redirect_uri = redirect_uri.strip()
+
+    # Optional: client_secret (public clients may not need this)
+    client_secret = _env_get(env, prefix, "OIDC_CLIENT_SECRET")
+    if client_secret and isinstance(client_secret, str) and client_secret.strip():
+        client_secret = client_secret.strip()
+    else:
+        # Try keyring, but don't fail if not found (public client)
+        client_secret = _get_secret_from_keyring(url, client_id)
+        # client_secret may still be None — that's OK for public clients
+
+    # Optional: allow insecure redirect (HTTP instead of HTTPS)
+    redirect_insecure_str = _env_get(env, prefix, "OIDC_REDIRECT_INSECURE")
+    redirect_url_allow_insecure = False
+    if redirect_insecure_str and str(redirect_insecure_str).strip():
+        redirect_url_allow_insecure = str(redirect_insecure_str).strip().lower() in ("1", "true", "yes", "y")
+
+    # Optional: WebFinger path prefix
+    webfinger_path_prefix = _env_get(env, prefix, "OIDC_WEBFINGER_PATH_PREFIX") or ""
+
+    # Optional: explicit endpoints (skip WebFinger discovery)
+    authorization_endpoint = _env_get(env, prefix, "OIDC_AUTHORIZATION_ENDPOINT")
+    if authorization_endpoint:
+        authorization_endpoint = authorization_endpoint.strip() or None
+
+    token_endpoint = _env_get(env, prefix, "OIDC_TOKEN_ENDPOINT")
+    if token_endpoint:
+        token_endpoint = token_endpoint.strip() or None
+
+    # Optional: login timeout
+    login_timeout = 60
+    login_timeout_str = _env_get(env, prefix, "OIDC_LOGIN_TIMEOUT")
+    if login_timeout_str and login_timeout_str.strip():
+        try:
+            login_timeout = int(login_timeout_str.strip())
+        except ValueError:
+            raise ValueError(
+                f"Environment variable {prefix}_OIDC_LOGIN_TIMEOUT must be an integer, " f"got: {login_timeout_str!r}"
+            )
+
+    # Optional: scope
+    scope_str = _env_get(env, prefix, "OIDC_SCOPE")
+    scope: list[str] | None = None
+    if scope_str and scope_str.strip():
+        scope = [s.strip() for s in scope_str.split(",") if s.strip()]
+
+    return {
+        "mode": "oidc",
+        "url": url,
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "redirect_url_allow_insecure": redirect_url_allow_insecure,
+        "client_secret": client_secret,
+        "scope": scope,
+        "authorization_endpoint": authorization_endpoint,
+        "token_endpoint": token_endpoint,
+        "login_timeout": login_timeout,
+        "verify_certificate": _parse_verify(env, prefix),
+        "webfinger_path_prefix": webfinger_path_prefix,
+    }
+
+
+def resolve_auth_args_from_env(prefix: str) -> dict[str, Any]:
+    """Resolve authentication arguments from environment variables.
+
+    Detects the authentication mode from ``{prefix}_MODE`` (or ``ODS_MODE``),
+    defaulting to ``"basic"`` for backward compatibility.
+
+    Returns a dict with ``"mode"`` plus all mode-specific parameters needed
+    by ``ODSConnectionManager.connect_with_factory()``.
+
+    Raises:
+        ValueError: If required variables are missing or mode is invalid.
+    """
+    env = os.environ
+
+    mode_str = _env_get(env, prefix, "MODE")
+    mode = mode_str.strip().lower() if mode_str and mode_str.strip() else "basic"
+
+    if mode not in VALID_MODES:
+        raise ValueError(
+            f"Invalid authentication mode: {mode!r}. " f"Set {prefix}_MODE to one of: {', '.join(VALID_MODES)}"
+        )
+
+    if mode == "basic":
+        return _resolve_basic_auth(env, prefix)
+    elif mode == "m2m":
+        return _resolve_m2m_auth(env, prefix)
+    elif mode == "oidc":
+        return _resolve_oidc_auth(env, prefix)
+    else:
+        raise ValueError(
+            f"Unhandled authentication mode: {mode!r}. " f"Set {prefix}_MODE to one of: {', '.join(VALID_MODES)}"
+        )

--- a/odsbox_jaquel_mcp/connection.py
+++ b/odsbox_jaquel_mcp/connection.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from fastmcp.exceptions import ToolError
 from odsbox import ConI
+from odsbox.con_i_factory import ConIFactory
 from odsbox.model_cache import ModelCache
 from odsbox.proto import ods
 
@@ -39,6 +40,50 @@ class ODSConnectionManager:
         return cls._instance
 
     @classmethod
+    def _init_from_con_i(cls, con_i: ConI, display_username: str) -> dict[str, Any]:
+        """Initialize connection state from an already-created ConI instance.
+
+        Shared helper used by both ``connect()`` and ``connect_with_factory()``.
+        Loads the model, populates ``_connection_info``, and returns the status dict.
+        """
+        instance = cls.get_instance()
+
+        # Close existing connection if any
+        if instance._con_i:
+            try:
+                instance._con_i.close()
+            except Exception:
+                pass
+
+        instance._con_i = con_i
+        instance._model_cache = con_i.mc
+        instance._model = con_i.model()
+
+        ao_test_entity_name = "AoTest"
+        if instance._model is not None and instance._model.entities is not None:
+            for _e_name, e in instance._model.entities.items():
+                if e.base_name.lower() == "aotest":
+                    ao_test_entity_name = e.name
+                    break
+
+        initial_query = {
+            ao_test_entity_name: {"name": {"$like": "*"}},
+            "$attributes": {"id": 1, "name": 1},
+            "$options": {"$rowlimit": 100},
+        }
+
+        instance._connection_info = {
+            "url": con_i.con_i_url(),
+            "username": display_username,
+            "con_i_url": con_i.con_i_url(),
+            "status": "connected",
+            "available_entities": list(instance._model.entities.keys()) if instance._model else [],
+            "initial_query": initial_query,
+        }
+
+        return {"message": "Connected to ODS server", "connection": instance._connection_info}
+
+    @classmethod
     def connect(cls, url: str, auth: tuple, **kwargs) -> dict[str, Any]:
         """Establish connection to ODS server.
 
@@ -51,47 +96,69 @@ class ODSConnectionManager:
             Connection status dict
         """
         try:
-            instance = cls.get_instance()
-            # Close existing connection if any
-            if instance._con_i:
-                try:
-                    instance._con_i.close()
-                except Exception:
-                    pass
-
-            # Establish new connection
-            instance._con_i = ConI(url=url, auth=auth, load_model=True, **kwargs)
-
-            # Load model
-            instance._model_cache = instance._con_i.mc
-            instance._model = instance._con_i.model()
-
-            ao_test_entity_name = "AoTest"
-            if instance._model is not None and instance._model.entities is not None:
-                for _e_name, e in instance._model.entities.items():
-                    if e.base_name.lower() == "aotest":
-                        ao_test_entity_name = e.name
-                        break
-
-            initial_query = {
-                ao_test_entity_name: {"name": {"$like": "*"}},
-                "$attributes": {"id": 1, "name": 1},
-                "$options": {"$rowlimit": 100},
-            }
-
-            instance._connection_info = {
-                "url": url,
-                "username": auth[0] if isinstance(auth, tuple) else "unknown",
-                "con_i_url": instance._con_i.con_i_url(),
-                "status": "connected",
-                "available_entities": list(instance._model.entities.keys()) if instance._model else [],
-                "initial_query": initial_query,
-            }
-
-            return {"message": "Connected to ODS server", "connection": instance._connection_info}
-
+            con_i = ConI(url=url, auth=auth, load_model=True, **kwargs)
+            display_username = auth[0] if isinstance(auth, tuple) else "unknown"
+            return cls._init_from_con_i(con_i, display_username)
         except Exception as e:
             raise ToolError(f"Connection failed: {e}") from e
+
+    @classmethod
+    def connect_with_factory(cls, auth_args: dict[str, Any]) -> dict[str, Any]:
+        """Establish connection using ConIFactory based on authentication mode.
+
+        Args:
+            auth_args: Dict from ``auth_factory.resolve_auth_args_from_env()`` containing
+                       ``mode`` plus all mode-specific parameters.
+
+        Returns:
+            Connection status dict
+        """
+        mode = auth_args["mode"]
+
+        try:
+            if mode == "basic":
+                con_i = ConIFactory.basic(
+                    url=auth_args["url"],
+                    username=auth_args["username"],
+                    password=auth_args["password"],
+                    verify_certificate=auth_args.get("verify_certificate", True),
+                )
+                display_username = auth_args["username"]
+
+            elif mode == "m2m":
+                con_i = ConIFactory.m2m(
+                    url=auth_args["url"],
+                    token_endpoint=auth_args["token_endpoint"],
+                    client_id=auth_args["client_id"],
+                    client_secret=auth_args["client_secret"],
+                    scope=auth_args.get("scope"),
+                    verify_certificate=auth_args.get("verify_certificate", True),
+                )
+                display_username = auth_args["client_id"]
+
+            elif mode == "oidc":
+                con_i = ConIFactory.oidc(
+                    url=auth_args["url"],
+                    client_id=auth_args["client_id"],
+                    redirect_uri=auth_args["redirect_uri"],
+                    redirect_url_allow_insecure=auth_args.get("redirect_url_allow_insecure", False),
+                    client_secret=auth_args.get("client_secret"),
+                    scope=auth_args.get("scope"),
+                    authorization_endpoint=auth_args.get("authorization_endpoint"),
+                    token_endpoint=auth_args.get("token_endpoint"),
+                    login_timeout=auth_args.get("login_timeout", 60),
+                    verify_certificate=auth_args.get("verify_certificate", True),
+                    webfinger_path_prefix=auth_args.get("webfinger_path_prefix", ""),
+                )
+                display_username = auth_args["client_id"]
+
+            else:
+                raise ValueError(f"Unknown authentication mode: {mode!r}")
+
+            return cls._init_from_con_i(con_i, display_username)
+
+        except Exception as e:
+            raise ToolError(f"Connection failed ({mode} mode): {e}") from e
 
     @classmethod
     def disconnect(cls) -> dict[str, Any]:

--- a/odsbox_jaquel_mcp/server.py
+++ b/odsbox_jaquel_mcp/server.py
@@ -18,6 +18,7 @@ from fastmcp import Context, FastMCP
 from pydantic import Field
 
 from . import __version__
+from .auth_factory import resolve_auth_args_from_env
 from .bulk_api_guide import BulkAPIGuide
 from .connection import ODSConnectionManager
 from .measurement_analysis import ComparisonResult, MeasurementAnalyzer
@@ -254,45 +255,30 @@ async def ods_connect_using_env(
 
     Default prefix is ODSBOX_MCP; set ODSBOX_MCP_ENV_PREFIX or pass env_prefix.
     Falls back to legacy ODS_ prefix variables.
+
+    Supports three authentication modes via {prefix}_MODE:
+    - basic (default): Username/password. Vars: URL, USERNAME, PASSWORD, VERIFY.
+    - m2m: OAuth2 client credentials. Vars: URL, M2M_TOKEN_ENDPOINT, M2M_CLIENT_ID,
+      M2M_CLIENT_SECRET, M2M_SCOPE (optional, comma-separated), VERIFY.
+    - oidc: OpenID Connect browser login. Vars: URL, OIDC_CLIENT_ID, OIDC_REDIRECT_URI,
+      OIDC_CLIENT_SECRET (optional), OIDC_WEBFINGER_PATH_PREFIX, OIDC_AUTHORIZATION_ENDPOINT,
+      OIDC_TOKEN_ENDPOINT, OIDC_LOGIN_TIMEOUT, OIDC_REDIRECT_INSECURE, OIDC_SCOPE, VERIFY.
+
+    Secrets (passwords, client_secrets) fall back to keyring when not in env.
     """
     env = os.environ
     resolved_prefix = env_prefix or env.get("ODSBOX_MCP_ENV_PREFIX") or "ODSBOX_MCP"
     if ctx:
         await ctx.info(f"Resolved env prefix: {resolved_prefix}")
 
-    def _env_get(key: str) -> str | None:
-        return env.get(f"{resolved_prefix}_{key}") or env.get(f"ODS_{key}")
+    auth_args = resolve_auth_args_from_env(resolved_prefix)
+    mode = auth_args["mode"]
 
-    url = _env_get("URL") or _env_get("API_URL")
-    if not url or not isinstance(url, str) or not url.strip():
-        raise ValueError(
-            f"Environment variable {resolved_prefix}_URL (or {resolved_prefix}_API_URL) "
-            "must be set to a non-empty string"
-        )
-
-    username = _env_get("USERNAME") or _env_get("USER")
-    if not username or not isinstance(username, str) or not username.strip():
-        raise ValueError(
-            f"Environment variable {resolved_prefix}_USERNAME (or {resolved_prefix}_USER) "
-            "must be set to a non-empty string"
-        )
-
-    password = _env_get("PASSWORD") or _env_get("PWD")
-    if not password or not isinstance(password, str) or not password.strip():
-        raise ValueError(
-            f"Environment variable {resolved_prefix}_PASSWORD (or {resolved_prefix}_PWD) "
-            "must be set to a non-empty string"
-        )
     if ctx:
-        await ctx.debug(f"Using URL: {url}, username: {username}")
+        await ctx.info(f"Authentication mode: {mode}")
 
-    verify_str = _env_get("VERIFY")
-    if verify_str is None or str(verify_str).strip() == "":
-        verify_bool = True
-    else:
-        verify_bool = str(verify_str).strip().lower() in ("1", "true", "yes", "y")
+    result = ODSConnectionManager.connect_with_factory(auth_args)
 
-    result = ODSConnectionManager.connect(url=url, auth=(username, password), verify_certificate=verify_bool)
     if ctx:
         await ctx.info("Connection established successfully")
     return result

--- a/odsbox_jaquel_mcp/server_instructions.md
+++ b/odsbox_jaquel_mcp/server_instructions.md
@@ -72,6 +72,7 @@ This MCP server helps you work with ASAM ODS data using odsbox Jaquel queries.
 - **Connection State**: Connection persists across tool calls. Call `ods_disconnect` when done.
 - **Bulk API**: For large timeseries data (submatrices), prefer `data_read_submatrix` over `query_execute`
 - **Pattern Matching**: `data_read_submatrix` supports wildcards for efficient data filtering (e.g., "Temp*", "*Speed")
+- **Authentication Modes**: `ods_connect_using_env` supports `basic` (default), `m2m`, and `oidc` modes via `{PREFIX}_MODE`.
 
 ## ❓ WHEN TO USE WHICH TOOL
 

--- a/odsbox_jaquel_mcp/server_instructions.md
+++ b/odsbox_jaquel_mcp/server_instructions.md
@@ -1,106 +1,46 @@
 # ASAM ODS Jaquel MCP Server
 
-This MCP server helps you work with ASAM ODS data using odsbox Jaquel queries.
+Helps an AI agent query and analyze ASAM ODS measurement data via Jaquel queries.
 
-## 🚀 QUICK START - Choose Your Path
+## Mandatory precondition
 
-**Path 1: Connect to ODS & Execute Queries**
-- `ods_connect` → `schema_list_entities` → `schema_test_to_measurement_hierarchy` → `query_execute`
-- Or: `data_read_submatrix` for efficient timeseries access
-- Generate reusable scripts: `data_generate_fetcher_script`
+Most tools require an active ODS connection. Always establish one first:
+- Use `ods_connect` (explicit credentials) or `ods_connect_using_env` (env-configured).
+- Connection is a singleton and persists across tool calls in the session.
+- Call `ods_disconnect` when done.
 
-**Path 2: Analysis & Visualization**
-- Execute queries to get data
-- `data_compare_measurements` for statistical analysis
-- `plot_comparison_notebook` for Jupyter notebooks
-- `plot_generate_code` for matplotlib visualizations
+## Tool selection guide
 
-## 📚 TOOL CATEGORIES
+| Intent | Tool |
+|---|---|
+| Connect with credentials | `ods_connect` |
+| Connect from environment / CI | `ods_connect_using_env` |
+| List all entity types | `schema_list_entities` |
+| Inspect fields of one entity | `schema_get_entity` |
+| Understand test→measurement hierarchy | `schema_test_to_measurement_hierarchy` |
+| Check a query before running it | `query_validate` or `query_describe` |
+| Look up an operator | `query_get_operator_docs` |
+| Get a query template | `query_get_pattern` or `query_generate_skeleton` |
+| Run a Jaquel query | `query_execute` |
+| List quantities in a submatrix | `data_get_quantities` |
+| Read timeseries / bulk data | `data_read_submatrix` |
+| Generate a Python fetcher script | `data_generate_fetcher_script` |
+| Navigate measurement hierarchy | `data_query_hierarchy` |
+| Compare measurements statistically | `data_compare_measurements` |
+| Generate a Jupyter notebook | `plot_comparison_notebook` |
+| Generate matplotlib code | `plot_generate_code` |
+| Learn the Bulk API | `help_bulk_api` |
 
-**Validation & Debugging**
-- Check queries: `query_validate`, `query_describe`
-- Check operators: `query_get_operator_docs`
+## Typical workflows
 
-**Query Building**
-- Skeletons: `query_generate_skeleton`
-- Patterns: `query_list_patterns`, `query_get_pattern`
+**Query workflow**: `ods_connect` → `schema_list_entities` → `query_validate` → `query_execute`
 
-**Schema & Entity Inspection**
-- List entities: `schema_list_entities`, `schema_test_to_measurement_hierarchy`
-- Check fields: `schema_get_entity`, `schema_field_exists`
+**Timeseries workflow**: `ods_connect` → `data_get_quantities` → `data_read_submatrix`
 
-**ODS Connection**
-- Manage: `ods_connect`, `ods_connect_using_env`, `ods_disconnect`, `ods_get_connection_info`
+**Analysis workflow**: `query_execute` → `data_query_hierarchy` → `data_compare_measurements` → `plot_comparison_notebook`
 
-**Data Access**
-- Submatrix: `data_read_submatrix`, `data_get_quantities`
-- Scripts: `data_generate_fetcher_script`
+## Key behaviour notes
 
-**Analysis & Visualization**
-- Compare: `data_compare_measurements`, `data_query_hierarchy`
-- Notebooks: `plot_comparison_notebook`
-- Plots: `plot_generate_code`
-
-**Help & Documentation**
-- `help_bulk_api` - Comprehensive Bulk API guidance
-
-## 💡 COMMON WORKFLOWS
-
-**Workflow 1: Connect to ODS & Execute Query**
-1. `ods_connect` - Provide URL, username, password
-2. `schema_list_entities` - See available entities
-3. `schema_test_to_measurement_hierarchy` - Explore test to measurement structure
-4. `schema_get_entity` - Inspect entity fields
-5. `query_execute` - Run your query
-6. Analyze results with measurement tools
-
-**Workflow 2: Read Timeseries Data Efficiently**
-1. `data_get_quantities` - See available data
-2. `data_read_submatrix` - Fetch with pattern matching
-3. `data_generate_fetcher_script` - Create reusable Python script
-4. Use script for automation
-
-**Workflow 3: Compare Multiple Measurements**
-1. Execute query to get measurements
-2. `data_query_hierarchy` - Explore structure (extract_measurements, get_unique_quantities)
-3. `plot_comparison_notebook` - Create Jupyter notebook
-4. `data_compare_measurements` - Statistical analysis
-5. `plot_generate_code` - Matplotlib code for custom plots
-
-## ⚠️ KEY TIPS
-
-- **Connection State**: Connection persists across tool calls. Call `ods_disconnect` when done.
-- **Bulk API**: For large timeseries data (submatrices), prefer `data_read_submatrix` over `query_execute`
-- **Pattern Matching**: `data_read_submatrix` supports wildcards for efficient data filtering (e.g., "Temp*", "*Speed")
-- **Authentication Modes**: `ods_connect_using_env` supports `basic` (default), `m2m`, and `oidc` modes via `{PREFIX}_MODE`.
-
-## ❓ WHEN TO USE WHICH TOOL
-
-**"How do I...?"**
-- "...start building a query?" → `query_list_patterns`
-- "...validate query?" → `query_describe`
-- "...connect to ODS?" → `ods_connect`
-- "...connect to ASAM ODS?" → `ods_connect`
-- "...find entities?" → `schema_list_entities`
-- "...understand structure?" → `schema_test_to_measurement_hierarchy` or `schema_get_entity`
-- "...read measurement data?" → `data_read_submatrix` or `query_execute`
-- "...create a reusable script?" → `data_generate_fetcher_script`
-- "...compare measurements?" → `data_compare_measurements` + `plot_comparison_notebook`
-- "...understand submatrix data access?" → `help_bulk_api`
-
-## 📖 INTERACTIVE STARTING PROMPTS
-
-Use these for guided workflows:
-- `connect_ods_server` - Learn connection management
-- `query_validate` - Validate queries step-by-step
-- `explore_patterns` - Discover query patterns
-- `timeseries_access` - Learn Bulk API 3-step workflow
-- `analyze_measurements` - Statistical analysis & visualization
-
-## 🔗 DOCUMENTATION & EXAMPLES
-
-- **Tool Guide**: https://github.com/totonga/odsbox-jaquel-mcp/blob/main/TOOLS_GUIDE.md
-- **Prompts Guide**: https://github.com/totonga/odsbox-jaquel-mcp/blob/main/PROMPTS.md
-- **Full README**: https://github.com/totonga/odsbox-jaquel-mcp
-
-**Pro Tip**: Always review tool descriptions and examples to understand input/output formats!
+- `data_read_submatrix` supports wildcard column patterns (`"Temp*"`, `"*Speed"`); prefer it over `query_execute` for large timeseries.
+- `ods_connect_using_env` supports auth modes `basic` (default), `m2m`, and `oidc` via `{PREFIX}_MODE`.
+- Use starting prompts (`connect_ods_server`, `timeseries_access`, `analyze_measurements`, etc.) to guide users through multi-step workflows.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,10 +38,11 @@ classifiers = [
 ]
 dependencies = [
     "fastmcp>=3.0.0",
-    "odsbox>=1.0.15",
+    "odsbox[oidc]>=1.2.0",
     "pip-system-certs",
     "matplotlib",
     "Jinja2>=3.0",
+    "keyring>=25.7.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_auth_factory.py
+++ b/tests/test_auth_factory.py
@@ -1,0 +1,379 @@
+"""Tests for auth_factory module — environment variable resolution and keyring fallback."""
+
+from unittest.mock import patch
+
+import pytest
+
+from odsbox_jaquel_mcp.auth_factory import resolve_auth_args_from_env
+
+
+class TestResolveMode:
+    """Test mode detection and validation."""
+
+    def test_default_mode_is_basic(self, monkeypatch):
+        """When MODE is not set, defaults to basic."""
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_USERNAME", "user")
+        monkeypatch.setenv("ODSBOX_MCP_PASSWORD", "pass")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+        assert result["mode"] == "basic"
+
+    def test_explicit_basic_mode(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "basic")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_USERNAME", "user")
+        monkeypatch.setenv("ODSBOX_MCP_PASSWORD", "pass")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+        assert result["mode"] == "basic"
+
+    def test_m2m_mode(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "m2m")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_TOKEN_ENDPOINT", "http://auth/token")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_ID", "my-client")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_SECRET", "my-secret")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+        assert result["mode"] == "m2m"
+
+    def test_oidc_mode(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "oidc")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_CLIENT_ID", "my-client")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_REDIRECT_URI", "http://127.0.0.1:1234")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+        assert result["mode"] == "oidc"
+
+    def test_invalid_mode_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "foobar")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+
+        with pytest.raises(ValueError, match="Invalid authentication mode.*foobar"):
+            resolve_auth_args_from_env("ODSBOX_MCP")
+
+    def test_mode_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "M2M")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_TOKEN_ENDPOINT", "http://auth/token")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_ID", "cid")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_SECRET", "sec")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+        assert result["mode"] == "m2m"
+
+    def test_mode_from_legacy_prefix(self, monkeypatch):
+        """MODE can also be read from ODS_ legacy prefix."""
+        monkeypatch.setenv("ODS_MODE", "m2m")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_TOKEN_ENDPOINT", "http://auth/token")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_ID", "cid")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_SECRET", "sec")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+        assert result["mode"] == "m2m"
+
+
+class TestBasicMode:
+    """Test basic authentication mode resolution."""
+
+    def test_all_env_vars_set(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_USERNAME", "admin")
+        monkeypatch.setenv("ODSBOX_MCP_PASSWORD", "secret123")
+        monkeypatch.setenv("ODSBOX_MCP_VERIFY", "false")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["mode"] == "basic"
+        assert result["url"] == "http://server/api"
+        assert result["username"] == "admin"
+        assert result["password"] == "secret123"
+        assert result["verify_certificate"] is False
+
+    def test_legacy_env_vars_fallback(self, monkeypatch):
+        """Legacy ODS_ prefix variables should work."""
+        monkeypatch.setenv("ODS_URL", "http://server/api")
+        monkeypatch.setenv("ODS_USER", "admin")
+        monkeypatch.setenv("ODS_PWD", "secret123")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["url"] == "http://server/api"
+        assert result["username"] == "admin"
+        assert result["password"] == "secret123"
+
+    def test_api_url_alias(self, monkeypatch):
+        """API_URL should work as alternative to URL."""
+        monkeypatch.setenv("ODSBOX_MCP_API_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_USERNAME", "user")
+        monkeypatch.setenv("ODSBOX_MCP_PASSWORD", "pass")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+        assert result["url"] == "http://server/api"
+
+    def test_missing_url_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_USERNAME", "user")
+        monkeypatch.setenv("ODSBOX_MCP_PASSWORD", "pass")
+
+        with pytest.raises(ValueError, match="ODSBOX_MCP_URL"):
+            resolve_auth_args_from_env("ODSBOX_MCP")
+
+    def test_missing_username_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_PASSWORD", "pass")
+
+        with pytest.raises(ValueError, match="ODSBOX_MCP_USERNAME"):
+            resolve_auth_args_from_env("ODSBOX_MCP")
+
+    def test_missing_password_no_keyring_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_USERNAME", "user")
+
+        with patch("odsbox_jaquel_mcp.auth_factory._get_secret_from_keyring", return_value=None):
+            with pytest.raises(ValueError, match="keyring set"):
+                resolve_auth_args_from_env("ODSBOX_MCP")
+
+    def test_password_from_keyring(self, monkeypatch):
+        """When PASSWORD not in env, fall back to keyring."""
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_USERNAME", "admin")
+
+        with patch(
+            "odsbox_jaquel_mcp.auth_factory._get_secret_from_keyring",
+            return_value="keyring-password",
+        ) as mock_kr:
+            result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["password"] == "keyring-password"
+        mock_kr.assert_called_once_with("http://server/api", "admin")
+
+    def test_verify_defaults_to_true(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_USERNAME", "user")
+        monkeypatch.setenv("ODSBOX_MCP_PASSWORD", "pass")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+        assert result["verify_certificate"] is True
+
+    def test_custom_prefix(self, monkeypatch):
+        """Custom prefix should be used for all lookups."""
+        monkeypatch.setenv("MY_APP_URL", "http://custom/api")
+        monkeypatch.setenv("MY_APP_USERNAME", "user")
+        monkeypatch.setenv("MY_APP_PASSWORD", "pass")
+
+        result = resolve_auth_args_from_env("MY_APP")
+
+        assert result["url"] == "http://custom/api"
+        assert result["username"] == "user"
+
+
+class TestM2MMode:
+    """Test M2M authentication mode resolution."""
+
+    def test_all_env_vars_set(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "m2m")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_TOKEN_ENDPOINT", "http://auth/token")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_ID", "my-client")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_SECRET", "my-secret")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_SCOPE", "api,admin")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["mode"] == "m2m"
+        assert result["url"] == "http://server/api"
+        assert result["token_endpoint"] == "http://auth/token"
+        assert result["client_id"] == "my-client"
+        assert result["client_secret"] == "my-secret"
+        assert result["scope"] == ["api", "admin"]
+
+    def test_scope_is_none_when_not_set(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "m2m")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_TOKEN_ENDPOINT", "http://auth/token")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_ID", "cid")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_SECRET", "sec")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+        assert result["scope"] is None
+
+    def test_missing_token_endpoint_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "m2m")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_ID", "cid")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_SECRET", "sec")
+
+        with pytest.raises(ValueError, match="M2M_TOKEN_ENDPOINT"):
+            resolve_auth_args_from_env("ODSBOX_MCP")
+
+    def test_missing_client_id_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "m2m")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_TOKEN_ENDPOINT", "http://auth/token")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_SECRET", "sec")
+
+        with pytest.raises(ValueError, match="M2M_CLIENT_ID"):
+            resolve_auth_args_from_env("ODSBOX_MCP")
+
+    def test_missing_secret_no_keyring_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "m2m")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_TOKEN_ENDPOINT", "http://auth/token")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_ID", "cid")
+
+        with patch("odsbox_jaquel_mcp.auth_factory._get_secret_from_keyring", return_value=None):
+            with pytest.raises(ValueError, match="keyring set"):
+                resolve_auth_args_from_env("ODSBOX_MCP")
+
+    def test_client_secret_from_keyring(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "m2m")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_TOKEN_ENDPOINT", "http://auth/token")
+        monkeypatch.setenv("ODSBOX_MCP_M2M_CLIENT_ID", "my-client")
+
+        with patch(
+            "odsbox_jaquel_mcp.auth_factory._get_secret_from_keyring",
+            return_value="kr-secret",
+        ) as mock_kr:
+            result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["client_secret"] == "kr-secret"
+        mock_kr.assert_called_once_with("http://auth/token", "my-client")
+
+
+class TestOIDCMode:
+    """Test OIDC authentication mode resolution."""
+
+    def test_minimal_oidc(self, monkeypatch):
+        """OIDC with just required fields — WebFinger discovery."""
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "oidc")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_CLIENT_ID", "my-client")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_REDIRECT_URI", "http://127.0.0.1:1234")
+
+        with patch("odsbox_jaquel_mcp.auth_factory._get_secret_from_keyring", return_value=None):
+            result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["mode"] == "oidc"
+        assert result["url"] == "http://server/api"
+        assert result["client_id"] == "my-client"
+        assert result["redirect_uri"] == "http://127.0.0.1:1234"
+        assert result["client_secret"] is None  # public client
+        assert result["redirect_url_allow_insecure"] is False
+        assert result["login_timeout"] == 60
+        assert result["webfinger_path_prefix"] == ""
+
+    def test_oidc_with_explicit_endpoints(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "oidc")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_CLIENT_ID", "my-client")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_REDIRECT_URI", "http://127.0.0.1:1234")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_AUTHORIZATION_ENDPOINT", "http://auth/authorize")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_TOKEN_ENDPOINT", "http://auth/token")
+
+        with patch("odsbox_jaquel_mcp.auth_factory._get_secret_from_keyring", return_value=None):
+            result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["authorization_endpoint"] == "http://auth/authorize"
+        assert result["token_endpoint"] == "http://auth/token"
+
+    def test_oidc_with_all_options(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "oidc")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_CLIENT_ID", "my-client")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_REDIRECT_URI", "http://127.0.0.1:1234")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_CLIENT_SECRET", "oidc-secret")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_REDIRECT_INSECURE", "true")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_WEBFINGER_PATH_PREFIX", "/ods")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_LOGIN_TIMEOUT", "30")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_SCOPE", "openid,profile,email")
+        monkeypatch.setenv("ODSBOX_MCP_VERIFY", "false")
+
+        result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["client_secret"] == "oidc-secret"
+        assert result["redirect_url_allow_insecure"] is True
+        assert result["webfinger_path_prefix"] == "/ods"
+        assert result["login_timeout"] == 30
+        assert result["scope"] == ["openid", "profile", "email"]
+        assert result["verify_certificate"] is False
+
+    def test_missing_client_id_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "oidc")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_REDIRECT_URI", "http://127.0.0.1:1234")
+
+        with pytest.raises(ValueError, match="OIDC_CLIENT_ID"):
+            resolve_auth_args_from_env("ODSBOX_MCP")
+
+    def test_missing_redirect_uri_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "oidc")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_CLIENT_ID", "my-client")
+
+        with pytest.raises(ValueError, match="OIDC_REDIRECT_URI"):
+            resolve_auth_args_from_env("ODSBOX_MCP")
+
+    def test_client_secret_from_keyring(self, monkeypatch):
+        """OIDC client_secret falls back to keyring."""
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "oidc")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_CLIENT_ID", "my-client")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_REDIRECT_URI", "http://127.0.0.1:1234")
+
+        with patch(
+            "odsbox_jaquel_mcp.auth_factory._get_secret_from_keyring",
+            return_value="kr-oidc-secret",
+        ) as mock_kr:
+            result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["client_secret"] == "kr-oidc-secret"
+        mock_kr.assert_called_once_with("http://server/api", "my-client")
+
+    def test_no_client_secret_is_ok_for_public_client(self, monkeypatch):
+        """OIDC should NOT raise if client_secret is missing — public client."""
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "oidc")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_CLIENT_ID", "my-client")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_REDIRECT_URI", "http://127.0.0.1:1234")
+
+        with patch("odsbox_jaquel_mcp.auth_factory._get_secret_from_keyring", return_value=None):
+            result = resolve_auth_args_from_env("ODSBOX_MCP")
+
+        assert result["client_secret"] is None
+
+    def test_invalid_login_timeout_raises(self, monkeypatch):
+        monkeypatch.setenv("ODSBOX_MCP_MODE", "oidc")
+        monkeypatch.setenv("ODSBOX_MCP_URL", "http://server/api")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_CLIENT_ID", "my-client")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_REDIRECT_URI", "http://127.0.0.1:1234")
+        monkeypatch.setenv("ODSBOX_MCP_OIDC_LOGIN_TIMEOUT", "not-a-number")
+
+        with pytest.raises(ValueError, match="OIDC_LOGIN_TIMEOUT.*integer"):
+            resolve_auth_args_from_env("ODSBOX_MCP")
+
+
+class TestKeyringFallback:
+    """Test keyring integration edge cases."""
+
+    def test_keyring_import_failure_returns_none(self):
+        """If keyring is not installed, _get_secret_from_keyring returns None."""
+        from odsbox_jaquel_mcp.auth_factory import _get_secret_from_keyring
+
+        with patch.dict("sys.modules", {"keyring": None}):
+            # Importing None module raises TypeError, caught by except Exception
+            result = _get_secret_from_keyring("service", "user")
+            assert result is None
+
+    def test_keyring_get_password_raises_returns_none(self):
+        """If keyring.get_password raises, _get_secret_from_keyring returns None."""
+        import keyring
+
+        from odsbox_jaquel_mcp.auth_factory import _get_secret_from_keyring
+
+        with patch.object(keyring, "get_password", side_effect=RuntimeError("no backend")):
+            result = _get_secret_from_keyring("svc", "usr")
+            assert result is None

--- a/tests/test_integration_ods_connection.py
+++ b/tests/test_integration_ods_connection.py
@@ -43,7 +43,7 @@ class TestODSIntegration:
 
         assert ODSConnectionManager.is_connected()
         assert result["connection"]["status"] == "connected"
-        assert result["connection"]["url"] == integration_credentials["url"]
+        assert result["connection"]["url"].startswith(integration_credentials["url"])
         assert result["connection"]["username"] == integration_credentials["username"]
 
     def test_list_entities(self, integration_credentials):

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -138,7 +138,7 @@ class TestMCPServer:
             url="http://test:8087/api", auth=("user", "pass"), verify_certificate=False
         )
 
-    @patch("odsbox_jaquel_mcp.server.ODSConnectionManager.connect")
+    @patch("odsbox_jaquel_mcp.server.ODSConnectionManager.connect_with_factory")
     @pytest.mark.asyncio
     async def test_call_tool_ods_connect_using_env_default_prefix(self, mock_connect, monkeypatch):
         """Test calling ods_connect_using_env tool with default prefix (ODSBOX_MCP)."""
@@ -152,11 +152,15 @@ class TestMCPServer:
         result = await ods_connect_using_env()
 
         assert isinstance(result, dict)
-        mock_connect.assert_called_once_with(
-            url="http://test:8087/api", auth=("user", "pass"), verify_certificate=False
-        )
+        mock_connect.assert_called_once()
+        auth_args = mock_connect.call_args[0][0]
+        assert auth_args["mode"] == "basic"
+        assert auth_args["url"] == "http://test:8087/api"
+        assert auth_args["username"] == "user"
+        assert auth_args["password"] == "pass"
+        assert auth_args["verify_certificate"] is False
 
-    @patch("odsbox_jaquel_mcp.server.ODSConnectionManager.connect")
+    @patch("odsbox_jaquel_mcp.server.ODSConnectionManager.connect_with_factory")
     @pytest.mark.asyncio
     async def test_call_tool_ods_connect_using_env_override_prefix(self, mock_connect, monkeypatch):
         """Test calling ods_connect_using_env tool with an explicit env_prefix."""
@@ -170,11 +174,15 @@ class TestMCPServer:
         result = await ods_connect_using_env(env_prefix="ODS")
 
         assert isinstance(result, dict)
-        mock_connect.assert_called_once_with(
-            url="http://test:8087/api", auth=("user", "pass"), verify_certificate=False
-        )
+        mock_connect.assert_called_once()
+        auth_args = mock_connect.call_args[0][0]
+        assert auth_args["mode"] == "basic"
+        assert auth_args["url"] == "http://test:8087/api"
+        assert auth_args["username"] == "user"
+        assert auth_args["password"] == "pass"
+        assert auth_args["verify_certificate"] is False
 
-    @patch("odsbox_jaquel_mcp.server.ODSConnectionManager.connect")
+    @patch("odsbox_jaquel_mcp.server.ODSConnectionManager.connect_with_factory")
     @pytest.mark.asyncio
     async def test_call_tool_ods_connect_using_env_fallback_to_ods_vars(self, mock_connect, monkeypatch):
         """Test that ods_connect_using_env falls back to legacy ODS_ env vars when ODSBOX_MCP_ vars are absent."""
@@ -193,11 +201,15 @@ class TestMCPServer:
         result = await ods_connect_using_env()
 
         assert isinstance(result, dict)
-        mock_connect.assert_called_once_with(
-            url="http://test:8087/api", auth=("user", "pass"), verify_certificate=True
-        )
+        mock_connect.assert_called_once()
+        auth_args = mock_connect.call_args[0][0]
+        assert auth_args["mode"] == "basic"
+        assert auth_args["url"] == "http://test:8087/api"
+        assert auth_args["username"] == "user"
+        assert auth_args["password"] == "pass"
+        assert auth_args["verify_certificate"] is True
 
-    @patch("odsbox_jaquel_mcp.server.ODSConnectionManager.connect")
+    @patch("odsbox_jaquel_mcp.server.ODSConnectionManager.connect_with_factory")
     @pytest.mark.asyncio
     async def test_call_tool_ods_connect_using_env_missing_required_env_vars(self, mock_connect, monkeypatch):
         """Test that missing required env vars raises an error."""

--- a/tests/test_ods_connection_manager_factory.py
+++ b/tests/test_ods_connection_manager_factory.py
@@ -1,0 +1,201 @@
+"""Tests for ODSConnectionManager.connect_with_factory() — ConIFactory dispatch."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from odsbox_jaquel_mcp import ODSConnectionManager
+
+
+class TestConnectWithFactory:
+    """Test connect_with_factory dispatches to correct ConIFactory methods."""
+
+    def setup_method(self):
+        """Reset singleton instance before each test."""
+        ODSConnectionManager._instance = None
+        ODSConnectionManager._con_i = None
+        ODSConnectionManager._model_cache = None
+        ODSConnectionManager._model = None
+        ODSConnectionManager._connection_info = {}
+
+    def _mock_con_i(self):
+        """Create a standard mock ConI instance."""
+        mock = Mock()
+        mock.con_i_url.return_value = "http://test:8087/api"
+        mock.mc = Mock()
+        model = Mock()
+        model.entities = {"Measurement": Mock(), "Test": Mock()}
+        mock.model.return_value = model
+        return mock
+
+    @patch("odsbox_jaquel_mcp.connection.ConIFactory")
+    def test_basic_mode(self, mock_factory):
+        """Basic mode calls ConIFactory.basic with correct args."""
+        mock_con_i = self._mock_con_i()
+        mock_factory.basic.return_value = mock_con_i
+
+        auth_args = {
+            "mode": "basic",
+            "url": "http://test:8087/api",
+            "username": "admin",
+            "password": "secret",
+            "verify_certificate": False,
+        }
+
+        result = ODSConnectionManager.connect_with_factory(auth_args)
+
+        mock_factory.basic.assert_called_once_with(
+            url="http://test:8087/api",
+            username="admin",
+            password="secret",
+            verify_certificate=False,
+        )
+        assert result["connection"]["username"] == "admin"
+        assert result["connection"]["status"] == "connected"
+        assert ODSConnectionManager.is_connected()
+
+    @patch("odsbox_jaquel_mcp.connection.ConIFactory")
+    def test_m2m_mode(self, mock_factory):
+        """M2M mode calls ConIFactory.m2m with correct args."""
+        mock_con_i = self._mock_con_i()
+        mock_factory.m2m.return_value = mock_con_i
+
+        auth_args = {
+            "mode": "m2m",
+            "url": "http://test:8087/api",
+            "token_endpoint": "http://auth/token",
+            "client_id": "my-client",
+            "client_secret": "my-secret",
+            "scope": ["api", "admin"],
+            "verify_certificate": True,
+        }
+
+        result = ODSConnectionManager.connect_with_factory(auth_args)
+
+        mock_factory.m2m.assert_called_once_with(
+            url="http://test:8087/api",
+            token_endpoint="http://auth/token",
+            client_id="my-client",
+            client_secret="my-secret",
+            scope=["api", "admin"],
+            verify_certificate=True,
+        )
+        assert result["connection"]["username"] == "my-client"
+        assert result["connection"]["status"] == "connected"
+
+    @patch("odsbox_jaquel_mcp.connection.ConIFactory")
+    def test_oidc_mode(self, mock_factory):
+        """OIDC mode calls ConIFactory.oidc with correct args."""
+        mock_con_i = self._mock_con_i()
+        mock_factory.oidc.return_value = mock_con_i
+
+        auth_args = {
+            "mode": "oidc",
+            "url": "http://test:8087/api",
+            "client_id": "oidc-client",
+            "redirect_uri": "http://127.0.0.1:1234",
+            "redirect_url_allow_insecure": True,
+            "client_secret": None,
+            "scope": ["openid"],
+            "authorization_endpoint": "http://auth/authorize",
+            "token_endpoint": "http://auth/token",
+            "login_timeout": 30,
+            "verify_certificate": True,
+            "webfinger_path_prefix": "/ods",
+        }
+
+        result = ODSConnectionManager.connect_with_factory(auth_args)
+
+        mock_factory.oidc.assert_called_once_with(
+            url="http://test:8087/api",
+            client_id="oidc-client",
+            redirect_uri="http://127.0.0.1:1234",
+            redirect_url_allow_insecure=True,
+            client_secret=None,
+            scope=["openid"],
+            authorization_endpoint="http://auth/authorize",
+            token_endpoint="http://auth/token",
+            login_timeout=30,
+            verify_certificate=True,
+            webfinger_path_prefix="/ods",
+        )
+        assert result["connection"]["username"] == "oidc-client"
+
+    @patch("odsbox_jaquel_mcp.connection.ConIFactory")
+    def test_oidc_minimal_defaults(self, mock_factory):
+        """OIDC with missing optional keys uses defaults via .get()."""
+        mock_con_i = self._mock_con_i()
+        mock_factory.oidc.return_value = mock_con_i
+
+        auth_args = {
+            "mode": "oidc",
+            "url": "http://test:8087/api",
+            "client_id": "cid",
+            "redirect_uri": "http://127.0.0.1:1234",
+        }
+
+        ODSConnectionManager.connect_with_factory(auth_args)
+
+        mock_factory.oidc.assert_called_once_with(
+            url="http://test:8087/api",
+            client_id="cid",
+            redirect_uri="http://127.0.0.1:1234",
+            redirect_url_allow_insecure=False,
+            client_secret=None,
+            scope=None,
+            authorization_endpoint=None,
+            token_endpoint=None,
+            login_timeout=60,
+            verify_certificate=True,
+            webfinger_path_prefix="",
+        )
+
+    @patch("odsbox_jaquel_mcp.connection.ConIFactory")
+    def test_connection_failure_wraps_in_tool_error(self, mock_factory):
+        """ConIFactory exceptions are wrapped in ToolError."""
+        mock_factory.basic.side_effect = Exception("auth failed")
+
+        auth_args = {
+            "mode": "basic",
+            "url": "http://test:8087/api",
+            "username": "user",
+            "password": "pass",
+        }
+
+        with pytest.raises(ToolError, match="Connection failed.*basic.*auth failed"):
+            ODSConnectionManager.connect_with_factory(auth_args)
+
+        assert not ODSConnectionManager.is_connected()
+
+    @patch("odsbox_jaquel_mcp.connection.ConIFactory")
+    def test_unknown_mode_raises_tool_error(self, mock_factory):
+        """Unknown mode raises ToolError via ValueError."""
+        auth_args = {"mode": "unknown_mode"}
+
+        with pytest.raises(ToolError, match="Unknown authentication mode"):
+            ODSConnectionManager.connect_with_factory(auth_args)
+
+    @patch("odsbox_jaquel_mcp.connection.ConIFactory")
+    def test_replaces_existing_connection(self, mock_factory):
+        """Calling connect_with_factory when already connected replaces connection."""
+        mock_con_i_1 = self._mock_con_i()
+        mock_con_i_2 = self._mock_con_i()
+        mock_con_i_2.con_i_url.return_value = "http://new-server/api"
+        mock_factory.basic.side_effect = [mock_con_i_1, mock_con_i_2]
+
+        auth_args = {
+            "mode": "basic",
+            "url": "http://test:8087/api",
+            "username": "user1",
+            "password": "pass1",
+        }
+
+        ODSConnectionManager.connect_with_factory(auth_args)
+        assert ODSConnectionManager.is_connected()
+
+        auth_args["username"] = "user2"
+        result = ODSConnectionManager.connect_with_factory(auth_args)
+
+        assert result["connection"]["username"] == "user2"
+        mock_con_i_1.close.assert_called_once()

--- a/uv.lock
+++ b/uv.lock
@@ -1879,17 +1879,32 @@ wheels = [
 ]
 
 [[package]]
+name = "oauthlib"
+version = "3.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/5f/19930f824ffeb0ad4372da4812c50edbd1434f678c90c2733e1188edfc63/oauthlib-3.3.1.tar.gz", hash = "sha256:0f0f8aa759826a193cf66c12ea1af1637f87b9b4622d46e866952bb022e538c9", size = 185918, upload-time = "2025-06-19T22:48:08.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/9c/92789c596b8df838baa98fa71844d84283302f7604ed565dafe5a6b5041a/oauthlib-3.3.1-py3-none-any.whl", hash = "sha256:88119c938d2b8fb88561af5f6ee0eec8cc8d552b7bb1f712743136eb7523b7a1", size = 160065, upload-time = "2025-06-19T22:48:06.508Z" },
+]
+
+[[package]]
 name = "odsbox"
-version = "1.0.17"
+version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pandas" },
     { name = "protobuf" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/7f/1f09927c1045cb709b3dc4426a91624292a94b1efa36587778f0071a9b87/odsbox-1.0.17.tar.gz", hash = "sha256:5f37df3a0ff4f163b06f11903cfed50b48aa428bd7d4dc170469006171f88bf7", size = 1315399, upload-time = "2026-02-05T15:09:22.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/65/78/380ebb4829a4bccc988a1cfb74259fd60add9c73149f5f316d9a989e3a6f/odsbox-1.2.0.tar.gz", hash = "sha256:185dd490f688e5e539a52980dd55123f9f3481ab322ae7e13a224103ba458ab5", size = 1330864, upload-time = "2026-04-03T21:09:41.717Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/b4/3db9837a1211bc2e14ee778b0fefe1b65909f5fade40819062212e36ca00/odsbox-1.0.17-py3-none-any.whl", hash = "sha256:0cb0946cadd8b68795efdc1e79a120ed881dcfa44289a566748de7aef26e73cb", size = 61980, upload-time = "2026-02-05T15:09:20.732Z" },
+    { url = "https://files.pythonhosted.org/packages/81/1e/3a61cf841229f32c45b23bab431c6e02c128f7eab2aa9f6764854bd1e4da/odsbox-1.2.0-py3-none-any.whl", hash = "sha256:5814de744855357a2cc80fd3ae89ef2a9b24fb61e8a065fae1c3052a08edbb78", size = 68073, upload-time = "2026-04-03T21:09:39.919Z" },
+]
+
+[package.optional-dependencies]
+oidc = [
+    { name = "pip-system-certs" },
+    { name = "requests-oauthlib" },
 ]
 
 [[package]]
@@ -1898,8 +1913,9 @@ source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "jinja2" },
+    { name = "keyring" },
     { name = "matplotlib" },
-    { name = "odsbox" },
+    { name = "odsbox", extra = ["oidc"] },
     { name = "pip-system-certs" },
 ]
 
@@ -1938,9 +1954,10 @@ requires-dist = [
     { name = "isort", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "jinja2", specifier = ">=3.0" },
     { name = "jupyter", marker = "extra == 'play'" },
+    { name = "keyring", specifier = ">=25.7.0" },
     { name = "matplotlib" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
-    { name = "odsbox", specifier = ">=1.0.15" },
+    { name = "odsbox", extras = ["oidc"], specifier = ">=1.2.0" },
     { name = "pandas-stubs", marker = "extra == 'dev'", specifier = ">=2.3" },
     { name = "pip-system-certs" },
     { name = "plotly", marker = "extra == 'play'" },
@@ -2777,6 +2794,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-oauthlib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "oauthlib" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces support for multiple authentication modes for connecting to ODS servers, enhancing flexibility and security. It adds a new `auth_factory` module to resolve authentication parameters from environment variables, supports keyring-based secret fallback, and updates both documentation and connection logic to reflect these changes. The connection manager now uses a factory approach to handle different authentication flows, including basic, machine-to-machine (M2M), and OpenID Connect (OIDC).

**Authentication enhancements:**

* Added new `auth_factory.py` module that resolves authentication parameters from environment variables, supporting three modes: `basic` (username/password), `m2m` (OAuth2 client credentials), and `oidc` (OpenID Connect interactive login). Secrets fall back to the system keyring if not set as environment variables. (`odsbox_jaquel_mcp/auth_factory.py`)
* Updated `ODSConnectionManager` to support a new `connect_with_factory` method, which uses the resolved authentication parameters and the `ConIFactory` to establish connections according to the selected mode. The connection logic is refactored for clarity and reusability. (`odsbox_jaquel_mcp/connection.py`) [[1]](diffhunk://#diff-a78b1304bb898364871db780ef288cfbf62cef80cfea9518e3f5aa3e65ff14c7L42-R60) [[2]](diffhunk://#diff-a78b1304bb898364871db780ef288cfbf62cef80cfea9518e3f5aa3e65ff14c7L83-R162) [[3]](diffhunk://#diff-a78b1304bb898364871db780ef288cfbf62cef80cfea9518e3f5aa3e65ff14c7R9)

**Documentation updates:**

* Expanded and clarified the list of supported environment variables in `README.md`, including new variables for M2M and OIDC modes, and added a reference to the detailed guide. Example configurations now demonstrate all three authentication modes. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R123-R134) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L337-R346) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L351-R368)
* Overhauled the authentication section in `TOOLS_GUIDE.md` to document the new modes, environment variable names, keyring fallback mechanism, and usage instructions. (`TOOLS_GUIDE.md`)

**Integration:**

* Updated server initialization to import and use the new authentication factory logic. (`odsbox_jaquel_mcp/server.py`)