### PR TITLE
fix: serialization issue with numpy float

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 
@@ -76,7 +76,7 @@ jobs:
         python-version: "3.13"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -68,7 +68,7 @@ jobs:
         python-version: "3.13"
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v6
+      uses: astral-sh/setup-uv@v7
       with:
         enable-cache: true
 

--- a/odsbox_jaquel_mcp/connection.py
+++ b/odsbox_jaquel_mcp/connection.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from typing import Any, Literal
 
 from fastmcp.exceptions import ToolError
@@ -321,7 +322,7 @@ class ODSConnectionManager:
             df = result.head(effective_rows)
 
             return {
-                "result": df.to_dict(orient=result_format),
+                "result": json.loads(df.to_json(orient=result_format)),
                 "total_rows": total_rows,
                 "returned_rows": len(df),
                 "truncated": total_rows > len(df),

--- a/tests/test_ods_connection_manager.py
+++ b/tests/test_ods_connection_manager.py
@@ -1,7 +1,10 @@
 """Tests for ODSConnectionManager."""
 
+import json
 from unittest.mock import Mock, patch
 
+import numpy as np
+import pandas as pd
 import pytest
 from fastmcp.exceptions import ToolError
 
@@ -164,11 +167,12 @@ class TestODSConnectionManager:
         mock_result.__len__ = Mock(return_value=3)
         mock_result.columns = ["id", "name"]
         mock_result.head.return_value = mock_result
-        mock_result.to_dict.return_value = {
+        _expected_result = {
             "columns": ["id", "name"],
             "index": [0, 1, 2],
             "data": [[1, "a"], [2, "b"], [3, "c"]],
         }
+        mock_result.to_json.return_value = json.dumps(_expected_result)
         mock_coni.query.return_value = mock_result
         mock_coni.con_i_url.return_value = "http://test:8087/api"
         mock_coni.mc = Mock()
@@ -183,7 +187,7 @@ class TestODSConnectionManager:
         query = {"TestEntity": {}}
         result = ODSConnectionManager.query(query)
 
-        assert result["result"] == mock_result.to_dict.return_value
+        assert result["result"] == _expected_result
         assert result["total_rows"] == 3
         assert result["returned_rows"] == 3
         assert result["truncated"] is False
@@ -195,6 +199,47 @@ class TestODSConnectionManager:
 
         with pytest.raises(ToolError, match="Not connected to ODS server"):
             ODSConnectionManager.query(query)
+
+    @patch("odsbox_jaquel_mcp.connection.ConI")
+    def test_query_result_numpy_floats_are_json_serializable(self, mock_coni_class):
+        """Regression: query results containing numpy float64 values must be JSON-serializable.
+
+        odsbox returns pandas DataFrames whose cells are numpy scalars.  Before the
+        fix, df.to_dict() preserved those numpy types and Pydantic's default_serializer
+        raised ``TypeError: 'float' object cannot be interpreted as an integer``.
+        """
+        mock_coni = Mock()
+        # Return a *real* DataFrame with numpy float64 columns, exactly as odsbox does.
+        df = pd.DataFrame(
+            {
+                "id": pd.array([1, 2, 3], dtype=np.int64),
+                "value": pd.array([1.1, 2.2, 3.3], dtype=np.float64),
+                "name": ["a", "b", "c"],
+            }
+        )
+        mock_coni.query.return_value = df
+        mock_coni.con_i_url.return_value = "http://test:8087/api"
+        mock_coni.mc = Mock()
+        mock_model = Mock()
+        mock_model.entities = {}
+        mock_coni.model.return_value = mock_model
+        mock_coni_class.return_value = mock_coni
+
+        ODSConnectionManager.connect(url="http://test:8087/api", auth=("user", "pass"))
+
+        result = ODSConnectionManager.query({"TestEntity": {}})
+
+        # The result dict must round-trip through json.dumps without raising.
+        serialized = json.dumps(result)
+        assert serialized  # non-empty
+
+        # Values must be native Python types, not numpy scalars.
+        data_values = result["result"]["data"]
+        for row in data_values:
+            for cell in row:
+                assert type(cell) in (int, float, str, bool, type(None)), (
+                    f"Expected native Python type, got {type(cell)}: {cell!r}"
+                )
 
     @patch("odsbox_jaquel_mcp.connection.ConI")
     def test_query_failure(self, mock_coni_class):


### PR DESCRIPTION
This pull request improves the handling of query results in the `ODSConnectionManager` to ensure they are always JSON-serializable, particularly when pandas DataFrames contain numpy scalar types. It also updates workflow dependencies and adds comprehensive tests to prevent regressions. The most important changes are:

**Query result serialization improvements:**

* Changed the query result conversion in `odsbox_jaquel_mcp/connection.py` to use `df.to_json()` followed by `json.loads()`, ensuring all returned data is JSON-serializable and native Python types are used, avoiding issues with numpy scalars.
* Added `import json` to `odsbox_jaquel_mcp/connection.py` to support the new serialization method.

**Testing enhancements:**

* Updated `tests/test_ods_connection_manager.py` to use the new serialization approach in mocks and assertions, ensuring consistency with the implementation. [[1]](diffhunk://#diff-bd747a83a4b69d5aa7f423e9a807a1588e3b4b50381944bcd3341eee45a13a6eL167-R175) [[2]](diffhunk://#diff-bd747a83a4b69d5aa7f423e9a807a1588e3b4b50381944bcd3341eee45a13a6eL186-R190)
* Added a regression test to verify that query results containing numpy float64 values are JSON-serializable and consist only of native Python types, preventing serialization errors.
* Added necessary imports (`json`, `numpy`, and `pandas`) to the test file for improved test coverage and reliability.

**Workflow dependency updates:**

* Updated the `astral-sh/setup-uv` GitHub Action version from `v6` or `v8.1.0` to `v7` in both `.github/workflows/build.yml` and `.github/workflows/pr-validation.yml` for consistency and to ensure up-to-date dependency management. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L38-R38) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L79-R79) [[3]](diffhunk://#diff-04af3c9c96028eebf4fa93d5c67e1fa08255fb7a3682f912ccd5bea1dff5ccd4L71-R71)